### PR TITLE
Added Input/Label elements, Fixed Broken Img

### DIFF
--- a/app/src/components/left/HTMLItem.tsx
+++ b/app/src/components/left/HTMLItem.tsx
@@ -119,14 +119,14 @@ const HTMLItem : React.FC<{
       })
     );
   };
-
+  // Caret updated the id's to reflect the new element types input and label
   return ( // HTML Elements
     <Grid item xs={5} key={`html-g${name}`}>
-      { id <= 11 &&
+      { id <= 13 &&
       <div ref={drag} className={isThemeLight ? `${classes.HTMLPanelItem} ${classes.lightThemeFontColor}` : `${classes.HTMLPanelItem} ${classes.darkThemeFontColor}`} id="HTMLItem">
         <h3>{name}</h3>
         </div>}
-      {id > 11 &&
+      {id > 13 &&
       <span id="customHTMLElement">
       <div ref={drag} className={isThemeLight ? `${classes.HTMLPanelItem} ${classes.lightThemeFontColor}` : `${classes.HTMLPanelItem} ${classes.darkThemeFontColor}`} id="HTMLItem">
         <h3>{name}</h3>

--- a/app/src/components/main/DemoRender.tsx
+++ b/app/src/components/main/DemoRender.tsx
@@ -28,10 +28,11 @@ const DemoRender = (props): JSX.Element => {
         const innerText = element.attributes.compText;
         const classRender = element.attributes.cssClasses;
         let renderedChildren;
-        if (element.children.length > 0) {
+        if (elementType !== 'input' && elementType !== 'img' && element.children.length > 0) {
           renderedChildren = componentBuilder(element.children);
         }
-        componentsToRender.push(<Box component={elementType} className={classRender} style={elementStyle} key={key} id={childId}>{innerText}{renderedChildren}</Box>);
+        if (elementType === 'input' || elementType === 'img') componentsToRender.push(<Box component={elementType} className={classRender} style={elementStyle} key={key} id={childId}>{innerText}</Box>);
+        else componentsToRender.push(<Box component={elementType} className={classRender} style={elementStyle} key={key} id={childId}>{innerText}{renderedChildren}</Box>);
         key += 1;
       }
     }

--- a/app/src/containers/RightContainer.tsx
+++ b/app/src/containers/RightContainer.tsx
@@ -147,7 +147,8 @@ const RightContainer = ({ isThemeLight }): JSX.Element => {
           focusTarget.child.style = focusChild.style;
           break;
         }
-        currentChild.children.forEach(child => searchArray.push(child));
+        // Caret Update
+        if (currentChild.name !== 'input' && currentChild.name !== 'img') currentChild.children.forEach(child => searchArray.push(child));
       }
 
       // if type is Component, use child's typeId to search through state components and find matching component's name

--- a/app/src/context/HTMLTypes.tsx
+++ b/app/src/context/HTMLTypes.tsx
@@ -113,8 +113,26 @@ const HTMLTypes: HTMLType[] = [
     id: 5,
     tag: 'span',
     name: 'Span',
-    style: { fontSize: '1.5em' },
+    style: { fontSize: '1em' },
     placeHolderShort: 'Span',
+    placeHolderLong: '',
+    icon: HeaderIcon
+  },
+  {
+    id: 12,
+    tag: 'input',
+    name: 'Input',
+    style: { fontSize: '1em' },
+    placeHolderShort: 'Input',
+    placeHolderLong: '',
+    icon: HeaderIcon
+  },
+  {
+    id: 13,
+    tag: 'label',
+    name: 'Label',
+    style: { fontSize: '1em' },
+    placeHolderShort: <label>Label</label>,
     placeHolderLong: '',
     icon: HeaderIcon
   }

--- a/app/src/helperFunctions/generateCode.ts
+++ b/app/src/helperFunctions/generateCode.ts
@@ -98,7 +98,19 @@ const generateUnformattedCode = (
             return `<${child.tag}${formatStyles(
               child.style
               )}>${writeNestedElements(child.children)}</${child.tag}>`;
-          } else if (child.tag === 'p') {
+          } 
+            // Caret Start
+            else if (child.tag === 'input') {
+            return `<${child.tag}${formatStyles(child.style)}>Input</${
+              child.tag
+            }>`;
+          } else if (child.tag === 'label') {
+            return `<${child.tag}${formatStyles(child.style)}>Label</${
+              child.tag
+            }>`;
+          } 
+            // Caret End
+            else if (child.tag === 'p') {
             return `<${child.tag}${formatStyles(
               child.style
             )}>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</${

--- a/app/src/helperFunctions/manageSeparators.ts
+++ b/app/src/helperFunctions/manageSeparators.ts
@@ -37,7 +37,8 @@ manageSeparators.handleSeparators = (arr: object[], str: string) => {
       manageSeparators.nextTopSeparatorId += 1;
     }
     // check is length is > 0 or it is a nested element
-    if (arr[index].children.length) {
+    // Caret Update
+    if ((arr[index].name !== 'input' && arr[index].name !== 'img') && arr[index].children.length) {
     // recursive call if children array
        (str === 'delete' || str === 'change position') ? manageSeparators.handleSeparators(arr[index].children, str) : manageSeparators.handleSeparators(arr[index].children);
     }

--- a/app/src/interfaces/Interfaces.ts
+++ b/app/src/interfaces/Interfaces.ts
@@ -1,4 +1,4 @@
-nsimport { DragObjectWithType } from 'react-dnd';
+import { DragObjectWithType } from 'react-dnd';
 
 export interface State {
   name: string;


### PR DESCRIPTION
 - Added Input/Label HTML elements as draggable options.
 - Fixed existing issue with Img and subsequently Input HTML elements. They explicitly cannot have children and it broke the application if anything was drag and dropped onto them. This issue is resolved.
 - Right after the html elements are created, the children property is deleted.
 - Fixed the cascade of breaks down the line when a children property is not present.
 - Omitted input and img types from extensive control logics.
 - Cleaned up some font sizing on the canvas display for input, label, and spans. 
 - Updated Id's in html item so that input and label instances can't be deleted and readded. They lack the x out button of  user added html elements.
 - Updated render logic to account for the missing children property